### PR TITLE
Fix support for ruby 3

### DIFF
--- a/lib/responses_api_gem/api_request.rb
+++ b/lib/responses_api_gem/api_request.rb
@@ -1,7 +1,7 @@
 module ResponsesApi
   class APIRequest
-    def self.execute(*args)
-      new(*args).tap do |request|
+    def self.execute(*args, **kwargs)
+      new(*args, **kwargs).tap do |request|
         raise StandardError, 'Failed asserting that the request succeeds' unless request.success?
       end
     end


### PR DESCRIPTION
Prevents `wrong number of arguments (given 2, expected 1)` error