### PR TITLE
avoid directly extending Hash and be more flexible with hashie version

### DIFF
--- a/lib/responses_api_gem/forms/requests/retrieve_responses_request.rb
+++ b/lib/responses_api_gem/forms/requests/retrieve_responses_request.rb
@@ -1,7 +1,6 @@
 require_relative 'form_request'
 require 'open-uri'
 require 'hashie'
-Hash.send :include, Hashie::Extensions
 
 module ResponsesApi
   class RetrieveResponsesRequest < FormRequest

--- a/responses_api_gem.gemspec
+++ b/responses_api_gem.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop'
 
-  spec.add_dependency 'hashie', '~> 3.0.0'
+  spec.add_dependency 'hashie', '>= 3', '< 4'
   spec.add_dependency 'json'
   spec.add_dependency 'rack'
   spec.add_dependency 'rest-client', '>=2'


### PR DESCRIPTION
don't include hashie directly into hash as this gem works without it and it causes stuff like https://github.com/hashie/hashie/issues/429 and be more flexible with hashie version